### PR TITLE
Add neon rectangle nodes and color-based node creation

### DIFF
--- a/src/components/CanvasGraph/canvas/v7/index.module.css
+++ b/src/components/CanvasGraph/canvas/v7/index.module.css
@@ -26,9 +26,19 @@ canvas {
     box-shadow: 0 2px 6px rgba(0,0,0,0.2);
 }
 
+
 .contextMenu li {
     padding: 6px 12px;
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.colorSquare {
+    width: 14px;
+    height: 14px;
+    border-radius: 2px;
 }
 
 .contextMenu li:hover {


### PR DESCRIPTION
## Summary
- replace circle nodes with neon-styled rectangles
- add pulsing animation for neon glow
- allow adding new nodes from a color‑picker context menu
- update styles for context menu

## Testing
- `npm run lint` *(fails: several lint errors in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68624e56f2b08324aa1ece6e2fcae29d